### PR TITLE
feat(errors): add formatError utility to treat Apollo errors

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   clearMocks: true,
   testEnvironment: "node",
+  testPathIgnorePatterns: ["node_modules", "dist"],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { ApolloServer } from "apollo-server";
 import schema from "./schema";
 import MetroStationsDataSource from "./datasources/MetroStationsDataSource";
+import formatError from "./utils/formatError";
 
 const server: ApolloServer = new ApolloServer({
   schema,
@@ -9,6 +10,7 @@ const server: ApolloServer = new ApolloServer({
       "editor.theme": "light",
     },
   },
+  formatError,
   introspection: true,
   dataSources: () => ({
     metroStations: new MetroStationsDataSource(),

--- a/src/utils/__tests__/formatError.test.ts
+++ b/src/utils/__tests__/formatError.test.ts
@@ -1,0 +1,35 @@
+import formatError from "../formatError";
+import { GraphQLError } from "graphql";
+import { ApolloError, ForbiddenError } from "apollo-server";
+
+const createGraphqlError = (message: string, status: number): GraphQLError =>
+  new GraphQLError(message, null, null, null, null, null, {
+    response: { status },
+  });
+
+describe("formatError", () => {
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+  });
+
+  it("Returns the same GraphQL Error on production (skips formatting)", () => {
+    process.env.NODE_ENV = "production";
+
+    const graphQLError = createGraphqlError("message", 500);
+    expect(formatError(graphQLError)).toBeInstanceOf(GraphQLError);
+  });
+
+  it("Returns ForbiddenError with the provided message when the error status is 403", () => {
+    const message = "Test message";
+    const error = formatError(createGraphqlError(message, 403));
+
+    expect(error).toBeInstanceOf(ForbiddenError);
+    expect(error.message).toBe(message);
+  });
+
+  it("Defaults to returning ApolloError", () => {
+    const error = formatError(createGraphqlError("", 500));
+
+    expect(error).toBeInstanceOf(ApolloError);
+  });
+});

--- a/src/utils/formatError.ts
+++ b/src/utils/formatError.ts
@@ -1,0 +1,22 @@
+import { ApolloError, ForbiddenError } from "apollo-server";
+import { GraphQLError } from "graphql";
+
+/*
+This helper function formats the errors to be apollo errors on development.
+Allows hiding some error information to the client
+*/
+const formatError = (error: GraphQLError): ApolloError | GraphQLError => {
+  if (process.env.NODE_ENV === "production") {
+    return error;
+  }
+
+  const status = error.extensions?.response?.status;
+  const message = error.message;
+
+  if (status === 403) {
+    return new ForbiddenError(message);
+  }
+  return new ApolloError(message);
+};
+
+export default formatError;


### PR DESCRIPTION
We use `formatErrors` on `ApolloServer` so the errors do not include all the information on production